### PR TITLE
Make the gem work again with the updated error section of the Geckoboard API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    geckoboard-push (0.1.3)
+    geckoboard-push (0.1.5)
       httparty (~> 0.13.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     fakeweb (1.3.0)
-    httparty (0.13.1)
+    httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)

--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,11 @@ task :default => ["test"]
 spec = Gem::Specification.new do |s|
 
   s.name              = "geckoboard-push"
-  s.version           = "0.1.4"
+  s.version           = "0.1.5"
   s.summary           = "Ruby library for pushing widget updates to Geckoboard."
   s.author            = "Elliott Draper"
   s.email             = "el@kickcode.com"
-  s.homepage          = "http://docs.geckoboard.com/api/push.html"
+  s.homepage          = "https://developer.geckoboard.com/#push-overview"
 
   s.has_rdoc          = true
   s.extra_rdoc_files  = %w(README.rdoc)

--- a/geckoboard-push.gemspec
+++ b/geckoboard-push.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{geckoboard-push}
-  s.version = "0.1.4"
+  s.version = "0.1.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Elliott Draper"]
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = %q{el@kickcode.com}
   s.extra_rdoc_files = ["README.rdoc"]
   s.files = ["README.rdoc", "test/geckoboard/push_test.rb", "lib/geckoboard/push.rb", "lib/geckoboard-push.rb"]
-  s.homepage = %q{http://docs.geckoboard.com/api/push.html}
+  s.homepage = %q{https://developer.geckoboard.com/#push-overview}
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -24,7 +24,7 @@ module Geckoboard
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
       raise Geckoboard::Push::Error.new("API key not configured.") if Geckoboard::Push.api_key.nil? || Geckoboard::Push.api_key.empty?
-      result = self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json}).parsed_response
+      result = self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json})
       # when exceeding the post-limit, the error message is in result["error"], not result["message"]
       # See https://developer.geckoboard.com/#errors
       raise Geckoboard::Push::Error.new(result["message"] || result["error"] || "unknown error") unless result.ok?

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -23,10 +23,13 @@ module Geckoboard
 
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
-      raise Geckoboard::Push::Error.new("Api key not configured.") if Geckoboard::Push.api_key.nil? || Geckoboard::Push.api_key.empty?
+      raise Geckoboard::Push::Error.new("API key not configured.") if Geckoboard::Push.api_key.nil? || Geckoboard::Push.api_key.empty?
       result = self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json}).parsed_response
-      raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
-      result["success"]
+      # when exceeding the post-limit, the error message is in result["error"], not result["message"]
+      # See https://developer.geckoboard.com/#errors
+      raise Geckoboard::Push::Error.new(result["message"] || result["error"] || "unknown error") unless result.ok?
+
+      result.ok?
     end
 
     # Value and previous value should be numeric values

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -21,8 +21,8 @@ class PushTest < Test::Unit::TestCase
 
   def test_invalid_key
     Geckoboard::Push.api_key = "invalid"
-    response = Net::HTTPOK.new("1.1", 200, "OK")
-    response.instance_variable_set(:@body, '{"success":false,"error":"Api key has wrong format. "}')
+    response = Net::HTTPForbidden.new("1.1", 403, "Forbidden")
+    response.instance_variable_set(:@body, '{"message":"Your API key is invalid"}')
     response.instance_variable_set(:@read, true)
     Net::HTTP.any_instance.expects(:request).returns(response)
     assert_raise Geckoboard::Push::Error do


### PR DESCRIPTION
* Geckoboard is now working with status codes, not with the `success` payload anymore
